### PR TITLE
Feat add responsiveness to dates

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -3,6 +3,8 @@
 <html>
 
 <head>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta charset="utf-8" />
   <title>&lt;my-element> Demo</title>
   <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@lit/lit-starter-ts",
-  "version": "1.0.4",
+  "name": "calendar-wc",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@lit/lit-starter-ts",
-      "version": "1.0.4",
+      "name": "calendar-wc",
+      "version": "1.0.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^2.2.4"

--- a/src/calendar-wc.styles.ts
+++ b/src/calendar-wc.styles.ts
@@ -11,7 +11,7 @@ const CalendarStyles = css`
   }
 
   .calendar {
-    width: 496px;
+    width: 100%;
     height: auto;
     border-radius: 8px;
   }
@@ -59,7 +59,7 @@ const CalendarStyles = css`
   }
 
   .month {
-    width: 240px;
+    width: 100%;
     height: auto;
   }
 
@@ -79,7 +79,7 @@ const CalendarStyles = css`
     justify-content: center;
     align-items: center;
     color: #bebebe;
-    width: 28px;
+    width: 14.2857%;
   }
 
   .clear-dates-btn,
@@ -132,8 +132,7 @@ const CalendarStyles = css`
 
   .days div {
     font-size: 0.75rem;
-    margin: 4.8px;
-    width: 23.2px;
+    width: 14.2857%;
     height: 26.4px;
     display: flex;
     justify-content: center;

--- a/src/calendar-wc.styles.ts
+++ b/src/calendar-wc.styles.ts
@@ -134,7 +134,7 @@ const CalendarStyles = css`
     font-size: 0.75rem;
     width: 14.2857%;
     height: 26.4px;
-      display: flex;
+    display: flex;
     justify-content: center;
     align-items: center;
     cursor: pointer;

--- a/src/calendar-wc.styles.ts
+++ b/src/calendar-wc.styles.ts
@@ -59,7 +59,7 @@ const CalendarStyles = css`
   }
 
   .month {
-    width: 100%;
+    width: 48%;
     height: auto;
   }
 
@@ -134,7 +134,7 @@ const CalendarStyles = css`
     font-size: 0.75rem;
     width: 14.2857%;
     height: 26.4px;
-    display: flex;
+      display: flex;
     justify-content: center;
     align-items: center;
     cursor: pointer;


### PR DESCRIPTION
This Pr makes the calendar component more responsive.

- The calendar width now stretches to fit the containing div size 

![image](https://github.com/molaycule/calendar-wc/assets/36817391/1a4ec932-eeb4-41e6-85f5-9545cebfd1ba)
![image](https://github.com/molaycule/calendar-wc/assets/36817391/e43929bb-383f-4a0f-a7c0-ea8619ae93b2)
